### PR TITLE
State machine module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/state-machine/readme.md
+++ b/state-machine/readme.md
@@ -1,0 +1,37 @@
+# State machine 
+
+## Purpose
+This module implements a declarative API for creating simple event driven Mealy state machines. 
+
+## Usage
+
+Event and state constants must be a power of two so that they can be properly 
+merged and bitmasked together
+
+Below is an example state machine
+
+```
+//   v----------r, bar()------------| 
+// START -------------e1,foo()--> FAULT-------------|
+//   ^--e2,foo()--|                 ^---e1, foo()---|
+
+// this defines any state transitions
+StateTransition_t tbtest[] = {
+	// on these states, during this event, execute this function, and move to this state
+	{START | FAULT, e1, foo, FAULT },
+	{FAULT, r, bar, START },
+	{START , e2, foo, START },
+};
+
+main(){
+	StateMachine_t test_sm = {
+		.name = "test_sm", // for debugging
+		.state = START, // initial state
+		.table = tbtest, // state transition table to reference
+		.tbsize = sizeof(tbtest), // size of stt
+	};
+
+	update_state(&test_sm, e1); // update the state by passing in any events that occur
+}
+
+```

--- a/state-machine/readme.md
+++ b/state-machine/readme.md
@@ -31,7 +31,8 @@ main(){
 		.tbsize = sizeof(tbtest), // size of stt
 	};
 
-	update_state(&test_sm, e1); // update the state by passing in any events that occur
+	// update the state by passing in any events that occur
+	bool state_changed = update_state(&test_sm, e1); 
 }
 
 ```

--- a/state-machine/state_machine.c
+++ b/state-machine/state_machine.c
@@ -1,0 +1,28 @@
+#include "state_machine.h"
+
+int update_state(StateMachine_t* sm, uint32_t event){
+
+	// get state lookup table
+	StateTransition_t* stt = sm->table;
+
+	for (int i = 0; i < sm->tbsize; i++){
+
+		StateTransition_t row = stt[i];
+
+		// look up state definition
+		if (sm->state & row.state_mask) {
+			
+			// check if event conditions match
+			if (event & row.event_mask)
+			{
+				row.action(row.next_state);
+				sm->state = row.next_state;
+
+				// don't break because a state may apply
+				// to multiple rows of the stt
+			}
+		}
+	}
+	return 1;
+}
+

--- a/state-machine/state_machine.c
+++ b/state-machine/state_machine.c
@@ -14,11 +14,11 @@ int update_state(StateMachine_t* sm, uint32_t event){
 			if (event & row.event_mask) {
 				row.action(row.next_state);
 				sm->state = row.next_state;
-				// don't break because a state may apply
-				// to multiple rows of the stt
+
+				return 1; // should only transition states once for a given event
 			}
 		}
 	}
-	return 1;
+	return 0; // no state change
 }
 

--- a/state-machine/state_machine.c
+++ b/state-machine/state_machine.c
@@ -4,20 +4,16 @@ int update_state(StateMachine_t* sm, uint32_t event){
 
 	// get state lookup table
 	StateTransition_t* stt = sm->table;
-
 	for (int i = 0; i < sm->tbsize; i++){
 
 		StateTransition_t row = stt[i];
-
 		// look up state definition
 		if (sm->state & row.state_mask) {
 			
 			// check if event conditions match
-			if (event & row.event_mask)
-			{
+			if (event & row.event_mask) {
 				row.action(row.next_state);
 				sm->state = row.next_state;
-
 				// don't break because a state may apply
 				// to multiple rows of the stt
 			}

--- a/state-machine/state_machine.h
+++ b/state-machine/state_machine.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "stdint.h"
+
+// a big state transition table.
+
+// gives the new state based on the struct 
+// executes an action on state exit and state enter
+// must use events as bit flags
+typedef void (*enter_action_t)(uint32_t);
+
+typedef struct StateTransition_t{
+	uint32_t state_mask;
+	uint32_t event_mask;
+	enter_action_t action;
+	uint32_t next_state;
+}StateTransition_t;
+
+typedef struct StateMachine_t{
+	const char* name;
+	StateTransition_t* table;
+	uint8_t tbsize;
+	uint32_t state;
+}StateMachine_t;
+
+int update_state(StateMachine_t* sm, uint32_t event);
+
+

--- a/state-machine/state_machine.h
+++ b/state-machine/state_machine.h
@@ -1,11 +1,6 @@
 #pragma once
 #include "stdint.h"
 
-// a big state transition table.
-
-// gives the new state based on the struct 
-// executes an action on state exit and state enter
-// must use events as bit flags
 typedef void (*enter_action_t)(uint32_t);
 
 typedef struct StateTransition_t{


### PR DESCRIPTION
refer to readme

This module acts as a refactor for the current VCU state machine, as well as an easier and simpler implementation for future state machines on the BMS. It uses the concept of state transition tables (STT) where an array of structs is used to define the behaviour of the state machine. At runtime, it will look for the current state and event in the STT, and transition if the definition exists.